### PR TITLE
go all in on node >18.7

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "grunt-shell": "4.0.0"
       },
       "engines": {
-        "node": ">16.16.0"
+        "node": ">18.7.0"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "directories": {},
   "engines": {
-    "node": ">16.16.0"
+    "node": ">18.7.0"
   },
   "homepage": "https://github.com/mobilemind/OpenInlets#readme",
   "keywords": [


### PR DESCRIPTION
package*.json, .github/workflows/npm-grunt.yml: go all in on node >18.7