### PR TITLE
DEMO: GitHub Actions- add error LGTM will catch

### DIFF
--- a/src/modifysupporturl.js
+++ b/src/modifysupporturl.js
@@ -19,7 +19,7 @@
         subid = '';
 
     // another suffix change
-    linktext = linktext.replace(/ - Apple( Developer)?$/, '');
+    linktext = document.title.replace(/ - Apple( Developer)?$/, '');
     // handle general support doc URLs
     if (lang.test(path)) {
         // replace language-locale with '/'


### PR DESCRIPTION
LGTM GitHub Action catches an error through static analysis.

However, it happens _after_ I make the PR, _and_ it doesn't prevent me from merging.

Given the error report, I can see that the JavaScript code will run, but it won't remove some suffixes from the page title, like:
*  `- Apple Support`
* `- Official Apple Support`

I made this exact error and the GitHub Action made me look at my code and fix it. I wouldn't have known otherwise until someone noticed it wasn't working and told me.
