### PR TITLE
chore(workflow): update npm-grunt to try to workaround node 18 check

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x,  23.x]
+        node-version: [ 22, 23 ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
chore(workflow): update npm-grunt to try to workaround node 18 check