### PR TITLE
fix(pre-push): add SIGPIPE trap to prevent broken pipe issues

### DIFF
--- a/pre-push
+++ b/pre-push
@@ -6,6 +6,9 @@
 # Redirect output to stderr.
 exec 1>&2
 
+# Ignore SIGPIPE to prevent broken pipe issues
+trap '' PIPE
+
 ## GLOBALS
 GITBRANCH="$(git rev-parse --abbrev-ref HEAD)"
 HOOKNAME="${0##*/}"


### PR DESCRIPTION
Add trap to ignore SIGPIPE signals, preventing the hook from terminating
unexpectedly if stderr pipe closes prematurely during command output.