### PR TITLE
fix(tracking-params-check.yml): param extraction

### DIFF
--- a/.github/workflows/tracking-params-check.yml
+++ b/.github/workflows/tracking-params-check.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           # Extract parameter names from DuckDuckGo JSON
           # DDG JSON has param as an array of objects w/ a "parameter" key
-          jq -r '.settings.parameters[].parameter' /tmp/ddg-params.json \
+          jq -r '.settings.parameters[]' /tmp/ddg-params.json \
             | sort > /tmp/ddg-list.txt
 
           # Extract quoted strings from utmstrip.ts (single-quoted identifiers)


### PR DESCRIPTION
Fix jq command to extract parameters correctly from DuckDuckGo JSON.