### PR TITLE
chore: update engines, dependencies & version for a release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,9 @@ minified JavaScript bookmarklets.
   scripts
 - **Lines of Code**: 21 TypeScript source files in `src/`, 6 Node.js scripts
   in `scripts/`
-- **Node Version Required**: >=24.13.1 (strict requirement via
+- **Node Version Required**: >=26.0.0 (strict requirement via
   `engineStrict: true`)
-- **npm Version Required**: >=11.8.0
+- **npm Version Required**: >=11.14.0
 - **Primary Output**: 21 `.bookmarklet` files in `dist/` directory
 
 ## Critical Build Instructions
@@ -26,8 +26,8 @@ minified JavaScript bookmarklets.
 **ALWAYS use the correct Node.js and npm versions.** The project uses
 `engineStrict: true` and requires:
 
-- Node.js >= 24.12.0
-- npm >= 11.6.0
+- Node.js >= 26.0.0
+- npm >= 11.14.0
 
 If you get version warnings during `npm ci`, the build may still work but is
 not supported.
@@ -172,7 +172,7 @@ Located in `.github/workflows/`:
 
 1. **`ci.yml`** - NodeJS Build
    - Triggers: push to main/hotfix, PRs to main
-   - Matrix: Node 24.x and 25.x
+   - Matrix: Node 26.x
    - Steps: Security audit → Install deps → Build & test → Generate SBOM
    - **Timeout**: 5 minutes
 
@@ -232,8 +232,8 @@ Check that builds still work after updates.
 **Issue**: If you see `EBADENGINE Unsupported engine` warnings:
 
 ```text
-npm warn EBADENGINE required: { node: '>=24.13.1', npm: '>=11.8.0' }
-npm warn EBADENGINE current: { node: 'v20.19.6', npm: '10.8.2' }
+npm warn EBADENGINE required: { node: '>=26.0.0', npm: '>=11.14.0' }
+npm warn EBADENGINE current: { node: 'v24.0.0', npm: '10.8.2' }
 ```
 
 **Workaround**: The build may work but is not officially supported. Upgrade

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,9 @@ minified JavaScript bookmarklets.
   scripts
 - **Lines of Code**: 21 TypeScript source files in `src/`, 6 Node.js scripts
   in `scripts/`
-- **Node Version Required**: >=26.0.0 (strict requirement via
+- **Node Version Required**: >=26.0 (strict requirement via
   `engineStrict: true`)
-- **npm Version Required**: >=11.14.0
+- **npm Version Required**: >=11.13
 - **Primary Output**: 21 `.bookmarklet` files in `dist/` directory
 
 ## Critical Build Instructions
@@ -26,8 +26,8 @@ minified JavaScript bookmarklets.
 **ALWAYS use the correct Node.js and npm versions.** The project uses
 `engineStrict: true` and requires:
 
-- Node.js >= 26.0.0
-- npm >= 11.14.0
+- Node.js >= 26.0
+- npm >= 11.13
 
 If you get version warnings during `npm ci`, the build may still work but is
 not supported.
@@ -232,8 +232,7 @@ Check that builds still work after updates.
 **Issue**: If you see `EBADENGINE Unsupported engine` warnings:
 
 ```text
-npm warn EBADENGINE required: { node: '>=26.0.0', npm: '>=11.14.0' }
-npm warn EBADENGINE current: { node: 'v24.0.0', npm: '10.8.2' }
+npm warn EBADENGINE required: { node: '>=26.0', npm: '>=11.13' }
 ```
 
 **Workaround**: The build may work but is not officially supported. Upgrade

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x, 25.x]
+        node-version: [26.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '26.x'
           cache: 'npm'
 
       - name: "Install Dependencies"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 26.x
           cache: 'npm'
 
       - name: Security Audit
@@ -184,7 +184,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 26.x
           cache: 'npm'
           cache-dependency-path: release-source/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ using a URL protocol scheme.
 
 ## Version Notes
 
-4.2.4 Update engines (node >=26.0.1, npm >=11.13.0) and dependencies
+4.2.4 Update engines (node >=26.0, npm >=11.13) and dependencies
 
 4.2.3 Fix unskim regex issue, update dependency integrate a "clean" into compile
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ using a URL protocol scheme.
 
 ## Version Notes
 
+4.2.4 Update engines (node 26.0, npm 11.14) and dependencies
+
 4.2.3 Fix unskim regex issue, update dependency integrate a "clean" into compile
 
 4.2.2 UtmStrip removes 7 additional ad-platform click IDs and affiliate tracking

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ using a URL protocol scheme.
 
 ## Version Notes
 
-4.2.4 Update engines (node >=26.0.0, npm >=11.14.0) and dependencies
+4.2.4 Update engines (node >=26.0.1, npm >=11.13.0) and dependencies
 
 4.2.3 Fix unskim regex issue, update dependency integrate a "clean" into compile
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ using a URL protocol scheme.
 
 ## Version Notes
 
-4.2.4 Update engines (node 26.0, npm 11.14) and dependencies
+4.2.4 Update engines (node >=26.0.0, npm >=11.14.0) and dependencies
 
 4.2.3 Fix unskim regex issue, update dependency integrate a "clean" into compile
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=26.0.0",
-        "npm": ">=11.14.0"
+        "node": ">=26.0",
+        "npm": ">=11.13"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "OpenInlets",
-  "version": "4.2.3",
+  "version": "4.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "OpenInlets",
-      "version": "4.2.3",
+      "version": "4.2.4",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/node": "25.6.0",
+        "@types/node": "25.6.2",
         "@typescript-eslint/eslint-plugin": "~8.59.2",
         "@typescript-eslint/parser": "~8.59.2",
         "eslint": "10.3.0",
         "eslint-plugin-no-unsanitized": "~4.1.5",
         "globals": "17.6.0",
         "markdownlint-cli2": "~0.22.1",
-        "terser": "5.46.2",
+        "terser": "5.47.1",
         "typescript": "6.0.3"
       },
       "engines": {
-        "node": ">=24.13.1",
-        "npm": ">=11.8.0"
+        "node": ">=26.0.0",
+        "npm": ">=11.14.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -325,9 +325,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -353,9 +353,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1176,9 +1176,9 @@
       "license": "ISC"
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2343,9 +2343,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "typescript": "6.0.3"
   },
   "engines": {
-    "node": ">=26.0.0",
-    "npm": ">=11.14.0"
+    "node": ">=26.0",
+    "npm": ">=11.13"
   },
   "engineStrict": true,
   "homepage": "https://github.com/mobilemind/OpenInlets#readme",

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
   "description": "Project that makes Safari bookmarklets to automagically jump to the corresponding app and more.",
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/node": "25.6.0",
+    "@types/node": "25.6.2",
     "@typescript-eslint/eslint-plugin": "~8.59.2",
     "@typescript-eslint/parser": "~8.59.2",
     "eslint": "10.3.0",
     "eslint-plugin-no-unsanitized": "~4.1.5",
     "globals": "17.6.0",
     "markdownlint-cli2": "~0.22.1",
-    "terser": "5.46.2",
+    "terser": "5.47.1",
     "typescript": "6.0.3"
   },
   "engines": {
-    "node": ">=24.13.1",
-    "npm": ">=11.8.0"
+    "node": ">=26.0.0",
+    "npm": ">=11.14.0"
   },
   "engineStrict": true,
   "homepage": "https://github.com/mobilemind/OpenInlets#readme",
@@ -62,5 +62,5 @@
     "test": "npm run build && node scripts/test-utmstrip.js && npm run verify-build",
     "verify-build": "node scripts/verify-build.js"
   },
-  "version": "4.2.3"
+  "version": "4.2.4"
 }


### PR DESCRIPTION
chore: update engines, dependencies & version for a release

- node >= 26.0., npm >= 11.13
- update dependencies: @types/node 25.6.2, terser 5.47.1